### PR TITLE
Refactor default requests/responses

### DIFF
--- a/server/endpoint/health/searcher/endpoint.go
+++ b/server/endpoint/health/searcher/endpoint.go
@@ -79,8 +79,13 @@ func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		var serviceRequest searcher.Request
 		{
-			serviceRequest = searcher.DefaultRequest()
-			serviceRequest.ClusterID = request.(string)
+			clusterID, ok := request.(string)
+			if !ok {
+				return Response{}, microerror.Mask(clusterNotFoundError)
+			}
+			serviceRequest = searcher.Request{
+				ClusterID: clusterID,
+			}
 		}
 
 		serviceResponse, err := e.service.Health.Searcher.Search(ctx, serviceRequest)

--- a/service/health/searcher/aws.go
+++ b/service/health/searcher/aws.go
@@ -6,19 +6,9 @@ import (
 
 // searchAWSCR searches for the cluster config in AWSClusterConfigs resources.
 func (s *Service) searchAWSCR(ctx context.Context, request Request) (*Response, error) {
-	/*
-		awsClusterConfigName := fmt.Sprintf("%s-%s", request.ClusterID, "aws-cluster-config")
-		awsClusterConfig, err := s.G8sClient.CoreV1alpha1().AWSClusterConfigs(metav1.NamespaceDefault).Get(awsClusterConfigName, metav1.GetOptions{})
-		if errors.IsNotFound(err) {
-			return nil, microerror.Mask(clusterNotFoundError)
-		} else if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	*/
-
-	response := DefaultResponse()
-	//response.ClusterHealth = awsClusterConfig.GetName()
-	response.ClusterHealth = "green"
+	response := Response{
+		ClusterHealth: "green",
+	}
 
 	return &response, nil
 }

--- a/service/health/searcher/azure.go
+++ b/service/health/searcher/azure.go
@@ -2,25 +2,13 @@ package searcher
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// searchAWSCR searches for the cluster config in AWSClusterConfigs resources.
+// searchAzureCR searches for the cluster config in AWSClusterConfigs resources.
 func (s *Service) searchAzureCR(ctx context.Context, request Request) (*Response, error) {
-	awsClusterConfigName := fmt.Sprintf("%s-%s", request.ClusterID, "aws-cluster-config")
-	awsClusterConfig, err := s.G8sClient.CoreV1alpha1().AWSClusterConfigs(metav1.NamespaceDefault).Get(awsClusterConfigName, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		return nil, microerror.Mask(clusterNotFoundError)
-	} else if err != nil {
-		return nil, microerror.Mask(err)
+	response := Response{
+		ClusterHealth: "green",
 	}
-
-	response := DefaultResponse()
-	response.ClusterHealth = awsClusterConfig.GetName()
 
 	return &response, nil
 }

--- a/service/health/searcher/kvm.go
+++ b/service/health/searcher/kvm.go
@@ -2,25 +2,13 @@ package searcher
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// searchAWSCR searches for the cluster config in AWSClusterConfigs resources.
+// searchKVMCR searches for the cluster config in AWSClusterConfigs resources.
 func (s *Service) searchKVMCR(ctx context.Context, request Request) (*Response, error) {
-	awsClusterConfigName := fmt.Sprintf("%s-%s", request.ClusterID, "aws-cluster-config")
-	awsClusterConfig, err := s.G8sClient.CoreV1alpha1().AWSClusterConfigs(metav1.NamespaceDefault).Get(awsClusterConfigName, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		return nil, microerror.Mask(clusterNotFoundError)
-	} else if err != nil {
-		return nil, microerror.Mask(err)
+	response := Response{
+		ClusterHealth: "green",
 	}
-
-	response := DefaultResponse()
-	response.ClusterHealth = awsClusterConfig.GetName()
 
 	return &response, nil
 }

--- a/service/health/searcher/request.go
+++ b/service/health/searcher/request.go
@@ -4,10 +4,3 @@ package searcher
 type Request struct {
 	ClusterID string `json:"clusterID"`
 }
-
-// DefaultRequest provides a default request by best effort.
-func DefaultRequest() Request {
-	return Request{
-		ClusterID: "",
-	}
-}

--- a/service/health/searcher/response.go
+++ b/service/health/searcher/response.go
@@ -3,9 +3,3 @@ package searcher
 type Response struct {
 	ClusterHealth string `json:"clusterHealth"`
 }
-
-func DefaultResponse() Response {
-	return Response{
-		ClusterHealth: "",
-	}
-}


### PR DESCRIPTION
In modern services we're trying to avoid `Default*()`. Instead we should create the `Config{}` as it is used. This PR takes care of remaining instances of this pattern.

Towards https://github.com/giantswarm/giantswarm/issues/6893