### PR TITLE
Make g8sclient lowercase to fix build

### DIFF
--- a/service/health/searcher/kvm.go
+++ b/service/health/searcher/kvm.go
@@ -9,7 +9,7 @@ import (
 
 // searchKVMCR searches for the cluster config in AWSClusterConfigs resources.
 func (s *Service) searchKVMCR(ctx context.Context, request Request) (*Response, error) {
-	kvmCR, err := s.G8sClient.ProviderV1alpha1().KVMConfigs("default").Get(request.ClusterID, v1.GetOptions{})
+	kvmCR, err := s.g8sClient.ProviderV1alpha1().KVMConfigs("default").Get(request.ClusterID, v1.GetOptions{})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
I forgot to merge master into my last PR before squashing and merging. When it was merged to master, there was a naming issue from another PR. This fixes that problem.