### PR TITLE
Add DockerVolumeSize to health-service

### DIFF
--- a/server/endpoint/health/searcher/endpoint.go
+++ b/server/endpoint/health/searcher/endpoint.go
@@ -117,6 +117,7 @@ func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 			ClusterID: clusterID,
 			Nodes:     nodeResponse.Nodes,
 			Pods:      podResponse.Pods,
+			Spec:      hostResponse.Spec,
 		}
 
 		healthResponse, err := e.service.Health.Search(ctx, healthRequest)

--- a/server/endpoint/health/searcher/endpoint.go
+++ b/server/endpoint/health/searcher/endpoint.go
@@ -113,11 +113,13 @@ func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 		}
 
 		healthRequest := health.Request{
-			Cluster:   hostResponse.Status,
 			ClusterID: clusterID,
-			Nodes:     nodeResponse.Nodes,
-			Pods:      podResponse.Pods,
-			Spec:      hostResponse.Spec,
+			Cluster: health.Cluster{
+				Status: hostResponse.Status,
+				Nodes:  nodeResponse.Nodes,
+				Pods:   podResponse.Pods,
+				Spec:   hostResponse.Spec,
+			},
 		}
 
 		healthResponse, err := e.service.Health.Search(ctx, healthRequest)

--- a/server/endpoint/health/searcher/testdata/case-0-aws-awsconfig.json
+++ b/server/endpoint/health/searcher/testdata/case-0-aws-awsconfig.json
@@ -56,7 +56,7 @@
             },
             "masters": [
                 {
-                    "dockerVolumeSizeGB": 0,
+                    "dockerVolumeSizeGB": 10,
                     "imageID": "ami-90c152ff",
                     "instanceType": "m4.xlarge"
                 }
@@ -75,17 +75,17 @@
             },
             "workers": [
                 {
-                    "dockerVolumeSizeGB": 0,
+                    "dockerVolumeSizeGB": 10,
                     "imageID": "ami-90c152ff",
                     "instanceType": "m4.xlarge"
                 },
                 {
-                    "dockerVolumeSizeGB": 0,
+                    "dockerVolumeSizeGB": 10,
                     "imageID": "ami-90c152ff",
                     "instanceType": "m4.xlarge"
                 },
                 {
-                    "dockerVolumeSizeGB": 0,
+                    "dockerVolumeSizeGB": 10,
                     "imageID": "ami-90c152ff",
                     "instanceType": "m4.xlarge"
                 }

--- a/server/endpoint/health/searcher/testdata/case-0-aws.golden
+++ b/server/endpoint/health/searcher/testdata/case-0-aws.golden
@@ -23,7 +23,8 @@
                 "ephemeral_storage_capacity_bytes": 107321753600,
                 "ephemeral_storage_allocatable_bytes": 106248011776,
                 "attachable_volume_allocatable_count": 39,
-                "attachable_volume_capacity_count": 39
+                "attachable_volume_capacity_count": 39,
+                "docker_volume_size_gb": 10
             },
             "ready": true,
             "health": "green",
@@ -55,7 +56,8 @@
                 "ephemeral_storage_capacity_bytes": 107321753600,
                 "ephemeral_storage_allocatable_bytes": 106248011776,
                 "attachable_volume_allocatable_count": 39,
-                "attachable_volume_capacity_count": 39
+                "attachable_volume_capacity_count": 39,
+                "docker_volume_size_gb": 10
             },
             "ready": true,
             "health": "green",
@@ -87,7 +89,8 @@
                 "ephemeral_storage_capacity_bytes": 5843333120,
                 "ephemeral_storage_allocatable_bytes": 4769591296,
                 "attachable_volume_allocatable_count": 39,
-                "attachable_volume_capacity_count": 39
+                "attachable_volume_capacity_count": 39,
+                "docker_volume_size_gb": 10
             },
             "ready": true,
             "health": "green",
@@ -119,7 +122,8 @@
                 "ephemeral_storage_capacity_bytes": 107321753600,
                 "ephemeral_storage_allocatable_bytes": 106248011776,
                 "attachable_volume_allocatable_count": 39,
-                "attachable_volume_capacity_count": 39
+                "attachable_volume_capacity_count": 39,
+                "docker_volume_size_gb": 10
             },
             "ready": true,
             "health": "green",

--- a/server/endpoint/health/searcher/testdata/case-1-azure-azureconfig.json
+++ b/server/endpoint/health/searcher/testdata/case-1-azure-azureconfig.json
@@ -35,7 +35,7 @@
           },
           "masters": [
               {
-                  "dockerVolumeSizeGB": 0,
+                  "dockerVolumeSizeGB": 20,
                   "vmSize": "Standard_D2s_v3"
               }
           ],
@@ -47,15 +47,15 @@
           },
           "workers": [
               {
-                  "dockerVolumeSizeGB": 0,
+                  "dockerVolumeSizeGB": 20,
                   "vmSize": "Standard_D2s_v3"
               },
               {
-                  "dockerVolumeSizeGB": 0,
+                  "dockerVolumeSizeGB": 20,
                   "vmSize": "Standard_D2s_v3"
               },
               {
-                  "dockerVolumeSizeGB": 0,
+                  "dockerVolumeSizeGB": 20,
                   "vmSize": "Standard_D2s_v3"
               }
           ]

--- a/server/endpoint/health/searcher/testdata/case-1-azure.golden
+++ b/server/endpoint/health/searcher/testdata/case-1-azure.golden
@@ -23,7 +23,8 @@
                 "ephemeral_storage_capacity_bytes": 29137096704,
                 "ephemeral_storage_allocatable_bytes": 28063354880,
                 "attachable_volume_allocatable_count": 4,
-                "attachable_volume_capacity_count": 4
+                "attachable_volume_capacity_count": 4,
+                "docker_volume_size_gb": 20
             },
             "ready": true,
             "health": "green",
@@ -55,7 +56,8 @@
                 "ephemeral_storage_capacity_bytes": 29137096704,
                 "ephemeral_storage_allocatable_bytes": 28063354880,
                 "attachable_volume_allocatable_count": 4,
-                "attachable_volume_capacity_count": 4
+                "attachable_volume_capacity_count": 4,
+                "docker_volume_size_gb": 20
             },
             "ready": true,
             "health": "green",
@@ -87,7 +89,8 @@
                 "ephemeral_storage_capacity_bytes": 29137096704,
                 "ephemeral_storage_allocatable_bytes": 28063354880,
                 "attachable_volume_allocatable_count": 4,
-                "attachable_volume_capacity_count": 4
+                "attachable_volume_capacity_count": 4,
+                "docker_volume_size_gb": 20
             },
             "ready": true,
             "health": "green",
@@ -119,7 +122,8 @@
                 "ephemeral_storage_capacity_bytes": 29137096704,
                 "ephemeral_storage_allocatable_bytes": 28063354880,
                 "attachable_volume_allocatable_count": 4,
-                "attachable_volume_capacity_count": 4
+                "attachable_volume_capacity_count": 4,
+                "docker_volume_size_gb": 20
             },
             "ready": true,
             "health": "green",

--- a/server/endpoint/health/searcher/testdata/case-2-kvm-kvmconfig.json
+++ b/server/endpoint/health/searcher/testdata/case-2-kvm-kvmconfig.json
@@ -106,7 +106,7 @@
           {
             "cpus": 2,
             "disk": 40,
-            "dockerVolumeSizeGB": 0,
+            "dockerVolumeSizeGB": 30,
             "memory": "8G"
           }
         ],
@@ -136,19 +136,19 @@
           {
             "cpus": 3,
             "disk": 40,
-            "dockerVolumeSizeGB": 0,
+            "dockerVolumeSizeGB": 30,
             "memory": "3G"
           },
           {
             "cpus": 3,
             "disk": 40,
-            "dockerVolumeSizeGB": 0,
+            "dockerVolumeSizeGB": 30,
             "memory": "3G"
           },
           {
             "cpus": 3,
             "disk": 40,
-            "dockerVolumeSizeGB": 0,
+            "dockerVolumeSizeGB": 30,
             "memory": "3G"
           }
         ]

--- a/server/endpoint/health/searcher/testdata/case-2-kvm.golden
+++ b/server/endpoint/health/searcher/testdata/case-2-kvm.golden
@@ -23,7 +23,8 @@
                 "ephemeral_storage_capacity_bytes": 5358223360,
                 "ephemeral_storage_allocatable_bytes": 4284481536,
                 "attachable_volume_allocatable_count": 0,
-                "attachable_volume_capacity_count": 0
+                "attachable_volume_capacity_count": 0,
+                "docker_volume_size_gb": 30
             },
             "ready": true,
             "health": "green",
@@ -55,7 +56,8 @@
                 "ephemeral_storage_capacity_bytes": 42928701440,
                 "ephemeral_storage_allocatable_bytes": 41854959616,
                 "attachable_volume_allocatable_count": 0,
-                "attachable_volume_capacity_count": 0
+                "attachable_volume_capacity_count": 0,
+                "docker_volume_size_gb": 30
             },
             "ready": true,
             "health": "green",
@@ -87,7 +89,8 @@
                 "ephemeral_storage_capacity_bytes": 42928701440,
                 "ephemeral_storage_allocatable_bytes": 41854959616,
                 "attachable_volume_allocatable_count": 0,
-                "attachable_volume_capacity_count": 0
+                "attachable_volume_capacity_count": 0,
+                "docker_volume_size_gb": 30
             },
             "ready": true,
             "health": "green",
@@ -119,7 +122,8 @@
                 "ephemeral_storage_capacity_bytes": 42928701440,
                 "ephemeral_storage_allocatable_bytes": 41854959616,
                 "attachable_volume_allocatable_count": 0,
-                "attachable_volume_capacity_count": 0
+                "attachable_volume_capacity_count": 0,
+                "docker_volume_size_gb": 30
             },
             "ready": true,
             "health": "green",

--- a/service/health/key/node.go
+++ b/service/health/key/node.go
@@ -7,6 +7,8 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/giantswarm/health-service/service/host"
 )
 
 const (
@@ -66,6 +68,14 @@ func MemoryToInt(nodeMemory *resource.Quantity) int64 {
 		return 0
 	}
 	return memBytes
+}
+
+// NodeWorkerVolumeSize returns the first volume size found in a slice of Workers, or 0 if the list is empty.
+func NodeWorkerVolumeSize(workers []host.Worker) int64 {
+	if len(workers) > 0 {
+		return workers[0].DockerVolumeSizeGB
+	}
+	return 0
 }
 
 // NodeHasCondition returns true if the node conditions contains a condition of the given type and value.

--- a/service/health/request.go
+++ b/service/health/request.go
@@ -3,6 +3,8 @@ package health
 import (
 	v1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/health-service/service/host"
 )
 
 // Request is the configuration for the service action.
@@ -11,4 +13,5 @@ type Request struct {
 	Nodes     []v1.Node
 	Pods      []v1.Pod
 	Cluster   v1alpha1.StatusCluster
+	Spec      host.ProviderSpec
 }

--- a/service/health/request.go
+++ b/service/health/request.go
@@ -10,8 +10,13 @@ import (
 // Request is the configuration for the service action.
 type Request struct {
 	ClusterID string
-	Nodes     []v1.Node
-	Pods      []v1.Pod
-	Cluster   v1alpha1.StatusCluster
-	Spec      host.ProviderSpec
+	Cluster   Cluster
+}
+
+// Cluster represents the control plane and tenant cluster data received for performing health calculations
+type Cluster struct {
+	Nodes  []v1.Node
+	Pods   []v1.Pod
+	Status v1alpha1.StatusCluster
+	Spec   host.ProviderSpec
 }

--- a/service/health/service_test.go
+++ b/service/health/service_test.go
@@ -278,8 +278,10 @@ func Test_ClusterHealth(t *testing.T) {
 			}
 
 			request := Request{
-				Cluster: tc.clusterStatus,
-				Nodes:   tc.nodes,
+				Cluster: Cluster{
+					Status: tc.clusterStatus,
+					Nodes:  tc.nodes,
+				},
 			}
 			response, err := service.Search(context.Background(), request)
 
@@ -335,8 +337,10 @@ func Test_NodeParsing(t *testing.T) {
 				t.Fatal(err)
 			}
 			request := Request{
-				Nodes: []v1.Node{
-					node,
+				Cluster: Cluster{
+					Nodes: []v1.Node{
+						node,
+					},
 				},
 			}
 			response, err := service.Search(context.Background(), request)

--- a/service/health/types.go
+++ b/service/health/types.go
@@ -48,4 +48,5 @@ type NodeStatusMachineResources struct {
 	EphemeralStorageAvail             int64 `json:"ephemeral_storage_allocatable_bytes"`
 	AttachableVolumesAllocatableCount int64 `json:"attachable_volume_allocatable_count"`
 	AttachableVolumesCapacityCount    int64 `json:"attachable_volume_capacity_count"`
+	DockerVolumeSizeGB                int64 `json:"docker_volume_size_gb"`
 }

--- a/service/host/response.go
+++ b/service/host/response.go
@@ -6,7 +6,7 @@ import v1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 type Response struct {
 	Endpoint string                 `json:"endpoint"`
 	Status   v1alpha1.StatusCluster `json:"cluster"`
-	Spec     ProviderSpec           `json:"provider"`
+	Spec     ProviderSpec           `json:"provider_spec"`
 }
 
 type ProviderSpec struct {

--- a/service/host/response.go
+++ b/service/host/response.go
@@ -6,4 +6,13 @@ import v1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 type Response struct {
 	Endpoint string                 `json:"endpoint"`
 	Status   v1alpha1.StatusCluster `json:"cluster"`
+	Spec     ProviderSpec           `json:"provider"`
+}
+
+type ProviderSpec struct {
+	Workers []Worker
+}
+
+type Worker struct {
+	DockerVolumeSizeGB int64 `json:"docker_volume_size_gb"`
 }


### PR DESCRIPTION
Converts incoming Specs from each provider to a stripped-down local generic ProviderSpec. This can be expanded later if more spec fields are needed, or replaced with cluster api adoption.